### PR TITLE
Fix simple typo in python function higlighting & improve highlighting of c/cpp struct/class members.

### DIFF
--- a/plugin/neotags/c.vim
+++ b/plugin/neotags/c.vim
@@ -9,7 +9,8 @@ let g:neotags#c#c = {
 
 let g:neotags#c#m = {
             \   'group': 'cMemberTag',
-            \   'ignore': '(__anon[0-9a-f]+|[_\w]+::)'
+            \   'ignore': '(__anon[0-9a-f]+|[_\w]+::)',
+            \   'prefix': '\%(\>\%(\.\|->\)\)\@<='
             \ }
 
 let g:neotags#c#g = g:neotags#c#c

--- a/plugin/neotags/cpp.vim
+++ b/plugin/neotags/cpp.vim
@@ -14,7 +14,8 @@ let g:neotags#cpp#u = g:neotags#cpp#c
 
 let g:neotags#cpp#m = {
             \   'group': 'cppMemberTag',
-            \   'ignore': '(__anon[0-9a-f]+|[_\w]+::)'
+            \   'ignore': '(__anon[0-9a-f]+|[_\w]+::)',
+            \   'prefix': '\%(\>\%(\.\|->\)\)\@<='
             \ }
 
 let g:neotags#cpp#e = {

--- a/plugin/neotags/python.vim
+++ b/plugin/neotags/python.vim
@@ -16,5 +16,5 @@ let g:neotags#python#c = {
             \ }
 
 highlight def link PythonMethodTag Function
-highlight def link PythonFunction Function
+highlight def link PythonFunctionTag Function
 highlight def link PythonClassTag Type

--- a/rplugin/python3/neotags/neotags.py
+++ b/rplugin/python3/neotags/neotags.py
@@ -53,7 +53,6 @@ class Neotags(object):
         }
 
         self.__pattern = r'syntax match %s /%s\%%(%s\)%s/ containedin=ALLBUT,%s'
-        self.__pattern_cmember = r'syntax match %s /\%%(\>\%%(\.\|->\)\)\@<=\%%(%s\)\>/'
         self.__exists_buffer = {}
         self.__regex_buffer = {}
 
@@ -345,17 +344,14 @@ class Neotags(object):
 
         for i in range(0, len(group), self.__patternlength):
             current = group[i:i + self.__patternlength]
-            # if hlkey == '_Neotags_c_m_cMemberTag':
-            if re.match('_Neotags_.+?_m_(?:c|cpp)MemberTag', hlkey):
-                cmds.append(self.__pattern_cmember % (hlkey, '\|'.join(current)))
-            else:
-                cmds.append(self.__pattern % (
-                    hlkey,
-                    prefix,
-                    '\|'.join(current),
-                    suffix,
-                    ','.join(self.__notin + notin)
-                ))
+
+            cmds.append(self.__pattern % (
+                hlkey,
+                prefix,
+                '\|'.join(current),
+                suffix,
+                ','.join(self.__notin + notin)
+            ))
 
         if ft != self.__vim.api.eval('&ft'):
             self._debug_end('filetype changed aborting highlight')

--- a/rplugin/python3/neotags/neotags.py
+++ b/rplugin/python3/neotags/neotags.py
@@ -53,6 +53,7 @@ class Neotags(object):
         }
 
         self.__pattern = r'syntax match %s /%s\%%(%s\)%s/ containedin=ALLBUT,%s'
+        self.__pattern_cmember = r'syntax match %s /\%%(\>\%%(\.\|->\)\)\@<=\%%(%s\)\>/'
         self.__exists_buffer = {}
         self.__regex_buffer = {}
 
@@ -344,14 +345,17 @@ class Neotags(object):
 
         for i in range(0, len(group), self.__patternlength):
             current = group[i:i + self.__patternlength]
-
-            cmds.append(self.__pattern % (
-                hlkey,
-                prefix,
-                '\|'.join(current),
-                suffix,
-                ','.join(self.__notin + notin)
-            ))
+            # if hlkey == '_Neotags_c_m_cMemberTag':
+            if re.match('_Neotags_.+?_m_(?:c|cpp)MemberTag', hlkey):
+                cmds.append(self.__pattern_cmember % (hlkey, '\|'.join(current)))
+            else:
+                cmds.append(self.__pattern % (
+                    hlkey,
+                    prefix,
+                    '\|'.join(current),
+                    suffix,
+                    ','.join(self.__notin + notin)
+                ))
 
         if ft != self.__vim.api.eval('&ft'):
             self._debug_end('filetype changed aborting highlight')

--- a/rplugin/python3/neotags/tags
+++ b/rplugin/python3/neotags/tags
@@ -1,0 +1,60 @@
+Neotags	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^class Neotags(object):$/;"	c	language:Python
+__init__	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def __init__(self, vim):$/;"	m	language:Python	class:Neotags
+Neotags.__init__	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def __init__(self, vim):$/;"	m	language:Python	class:Neotags
+__void	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def __void(self, *args):$/;"	m	language:Python	class:Neotags	file:
+Neotags.__void	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def __void(self, *args):$/;"	m	language:Python	class:Neotags	file:
+init	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def init(self):$/;"	m	language:Python	class:Neotags
+Neotags.init	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def init(self):$/;"	m	language:Python	class:Neotags
+toggle	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def toggle(self):$/;"	m	language:Python	class:Neotags
+Neotags.toggle	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def toggle(self):$/;"	m	language:Python	class:Neotags
+update	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def update(self):$/;"	m	language:Python	class:Neotags
+Neotags.update	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def update(self):$/;"	m	language:Python	class:Neotags
+highlight	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def highlight(self, clear):$/;"	m	language:Python	class:Neotags
+Neotags.highlight	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def highlight(self, clear):$/;"	m	language:Python	class:Neotags
+_parsetags	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _parsetags(self, ft):$/;"	m	language:Python	class:Neotags
+Neotags._parsetags	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _parsetags(self, ft):$/;"	m	language:Python	class:Neotags
+_tags_order	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _tags_order(self, ft):$/;"	m	language:Python	class:Neotags
+Neotags._tags_order	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _tags_order(self, ft):$/;"	m	language:Python	class:Neotags
+_kill	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _kill(self, proc_pid):$/;"	m	language:Python	class:Neotags
+Neotags._kill	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _kill(self, proc_pid):$/;"	m	language:Python	class:Neotags
+_run_ctags	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _run_ctags(self):$/;"	m	language:Python	class:Neotags
+Neotags._run_ctags	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _run_ctags(self):$/;"	m	language:Python	class:Neotags
+_exists	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _exists(self, kind, var, default):$/;"	m	language:Python	class:Neotags
+Neotags._exists	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _exists(self, kind, var, default):$/;"	m	language:Python	class:Neotags
+_getbufferhl	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _getbufferhl(self):$/;"	m	language:Python	class:Neotags
+Neotags._getbufferhl	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _getbufferhl(self):$/;"	m	language:Python	class:Neotags
+_clear	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _clear(self):$/;"	m	language:Python	class:Neotags
+Neotags._clear	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _clear(self):$/;"	m	language:Python	class:Neotags
+_highlight	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _highlight(self, key, file, ft, hlgroup, group, prefix, suffix, notin):$/;"	m	language:Python	class:Neotags
+Neotags._highlight	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _highlight(self, key, file, ft, hlgroup, group, prefix, suffix, notin):$/;"	m	language:Python	class:Neotags
+_regexp	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _regexp(self, kind, var):$/;"	m	language:Python	class:Neotags
+Neotags._regexp	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _regexp(self, kind, var):$/;"	m	language:Python	class:Neotags
+_parseLine	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _parseLine(self, match, groups, languages):$/;"	m	language:Python	class:Neotags
+Neotags._parseLine	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _parseLine(self, match, groups, languages):$/;"	m	language:Python	class:Neotags
+_getTags	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _getTags(self, files, ft):$/;"	m	language:Python	class:Neotags
+Neotags._getTags	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _getTags(self, files, ft):$/;"	m	language:Python	class:Neotags
+_debug_start	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _debug_start(self):$/;"	m	language:Python	class:Neotags
+Neotags._debug_start	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _debug_start(self):$/;"	m	language:Python	class:Neotags
+_debug_echo	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _debug_echo(self, message):$/;"	m	language:Python	class:Neotags
+Neotags._debug_echo	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _debug_echo(self, message):$/;"	m	language:Python	class:Neotags
+_debug_end	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _debug_end(self, message):$/;"	m	language:Python	class:Neotags
+Neotags._debug_end	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _debug_end(self, message):$/;"	m	language:Python	class:Neotags
+_error	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _error(self, message):$/;"	m	language:Python	class:Neotags
+Neotags._error	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _error(self, message):$/;"	m	language:Python	class:Neotags
+_ctags_to_vim	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _ctags_to_vim(self, lang, languages):$/;"	m	language:Python	class:Neotags
+Neotags._ctags_to_vim	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _ctags_to_vim(self, lang, languages):$/;"	m	language:Python	class:Neotags
+_vim_to_ctags	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _vim_to_ctags(self, languages):$/;"	m	language:Python	class:Neotags
+Neotags._vim_to_ctags	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/neotags.py	/^    def _vim_to_ctags(self, languages):$/;"	m	language:Python	class:Neotags
+NeotagsHandlers	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/__init__.py	/^class NeotagsHandlers(object):$/;"	c	language:Python
+__init__	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/__init__.py	/^    def __init__(self, vim):$/;"	m	language:Python	class:NeotagsHandlers
+NeotagsHandlers.__init__	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/__init__.py	/^    def __init__(self, vim):$/;"	m	language:Python	class:NeotagsHandlers
+init	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/__init__.py	/^    def init(self, args):$/;"	m	language:Python	class:NeotagsHandlers
+NeotagsHandlers.init	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/__init__.py	/^    def init(self, args):$/;"	m	language:Python	class:NeotagsHandlers
+highlight	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/__init__.py	/^    def highlight(self, args):$/;"	m	language:Python	class:NeotagsHandlers
+NeotagsHandlers.highlight	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/__init__.py	/^    def highlight(self, args):$/;"	m	language:Python	class:NeotagsHandlers
+rehighlight	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/__init__.py	/^    def rehighlight(self, args):$/;"	m	language:Python	class:NeotagsHandlers
+NeotagsHandlers.rehighlight	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/__init__.py	/^    def rehighlight(self, args):$/;"	m	language:Python	class:NeotagsHandlers
+update	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/__init__.py	/^    def update(self, args):$/;"	m	language:Python	class:NeotagsHandlers
+NeotagsHandlers.update	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/__init__.py	/^    def update(self, args):$/;"	m	language:Python	class:NeotagsHandlers
+toggle	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/__init__.py	/^    def toggle(self, args):$/;"	m	language:Python	class:NeotagsHandlers
+NeotagsHandlers.toggle	/home/bml/Downloads/git/neotags.nvim/rplugin/python3/neotags/__init__.py	/^    def toggle(self, args):$/;"	m	language:Python	class:NeotagsHandlers


### PR DESCRIPTION
This tiny little pull request makes two changes.

1. I noticed that python functions were not being highlighted. Methods were, just not normal functions. After a quick glance at the source I saw that it was trying to link the non-existent "PythonFunction" group to Function rather than the correct "PythonFunctionTag". I fixed this typo and now everything is fine.
2. This change is a bit more dubious. It always bothered me that struct members would be blindly highlighted wherever they appeared, regardless of whether they were in any way part of a struct instance. For example every single instance of the word 'buf' would be highlighted if I were foolish enough to make that part of a struct. This made me basically not use this feature at all - I found it that annoying. Finally I decided to do something about it and originally made a simple change so that it now only ever highlights these after '.' or '->', which solves the problem, though it now does not highlight them in the original definition of the struct.

Again, the first change is pretty minor. Unless something was quite odd with my setup it should be a fix for everyone. The second change is not so obvious, I consider it an improvement, but that may be personal.

EDIT: When I wrote this thing at 4:30 am last night I couldn't make the prefix mechanism work for whatever reason, so I resorted to hackishly adding a second regex and arbitrary checks in the python source. Looking back, I easily got the system working and moved the changes to a new prefix for cMembers and cppMembers in their ".vim" files, which works just fine. I should really do these things _before_ I make pull requests. Oh well. With this commit, the python source is untouched, only the three ".vim" files are slightly changed.