### PR TITLE
Rename import neovim to pynvim (fix #36)

### DIFF
--- a/rplugin/python3/neotags/__init__.py
+++ b/rplugin/python3/neotags/__init__.py
@@ -4,50 +4,50 @@
 # Repository:  https://github.com/c0r73x/neotags.nvim
 #              Released under the MIT license
 # ============================================================================
-import neovim
+import pynvim
 from neotags.neotags import Neotags
 
 
-@neovim.plugin
+@pynvim.plugin
 class NeotagsHandlers(object):
 
     def __init__(self, vim):
         self.__vim = vim
         self.__neotags = Neotags(self.__vim)
 
-    @neovim.function('NeotagsInit')
+    @pynvim.function('NeotagsInit')
     def init(self, args):
         self.__vim.async_call(self.__neotags.init)
 
-    @neovim.function('NeotagsHighlight')
+    @pynvim.function('NeotagsHighlight')
     def highlight(self, args):
         self.__vim.async_call(self.__neotags.update, False)
 
-    @neovim.function('NeotagsRehighlight')
+    @pynvim.function('NeotagsRehighlight')
     def rehighlight(self, args):
         # self.__vim.async_call(self.__neotags.highlight, True)
         self.__vim.async_call(self.__neotags.update, True)
 
-    @neovim.function('NeotagsUpdate')
+    @pynvim.function('NeotagsUpdate')
     def update(self, args):
         self.__vim.async_call(self.__neotags.update, True)
 
-    @neovim.function('NeotagsToggle')
+    @pynvim.function('NeotagsToggle')
     def toggle(self, args):
         self.__vim.async_call(self.__neotags.toggle)
 
-    @neovim.function('NeotagsAddProject')
+    @pynvim.function('NeotagsAddProject')
     def setbase(self, args):
         self.__vim.async_call(self.__neotags.setBase, args)
 
-    @neovim.function('NeotagsRemoveProject')
+    @pynvim.function('NeotagsRemoveProject')
     def removebase(self, args):
         self.__vim.async_call(self.__neotags.removeBase, args)
 
-    @neovim.function('Neotags_Toggle_C_Binary')
+    @pynvim.function('Neotags_Toggle_C_Binary')
     def toggle_C_bin(self, args):
         self.__vim.async_call(self.__neotags.toggle_C_bin)
 
-    @neovim.function('Neotags_Toggle_Verbosity')
+    @pynvim.function('Neotags_Toggle_Verbosity')
     def toggle_verbosity(self, args):
         self.__vim.async_call(self.__neotags.toggle_verbosity)

--- a/rplugin/python3/neotags/neotags.py
+++ b/rplugin/python3/neotags/neotags.py
@@ -16,7 +16,7 @@ import subprocess
 import sys
 import time
 from copy import deepcopy
-from neovim.api.nvim import NvimError
+from pynvim.api import NvimError
 
 # sys.path.append(os.path.dirname(__file__))
 from neotags.utils import (do_set_base, do_remove_base, find_tags, strip_c,


### PR DESCRIPTION
Just a quick search and replace to update the python module name.